### PR TITLE
Add wifi driver rtl8189ftv for orange pi boards

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -210,7 +210,7 @@
   DEBUG_GROUP_YES="kodi+"
 
 # Default supported get handlers (archive, git, file etc.)
-  GET_HANDLER_SUPPORT="archive"
+  GET_HANDLER_SUPPORT="archive git"
 
 # Partition labels for USB/SD installation media
   DISTRO_BOOTLABEL="LIBREELEC"

--- a/packages/linux-drivers/allwinner/RTL8189FS-allw/package.mk
+++ b/packages/linux-drivers/allwinner/RTL8189FS-allw/package.mk
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+
+PKG_URL="https://github.com/jwrdegoede/rtl8189ES_linux.git"
+PKG_VERSION="d2b823144ed9f034563e1b1970b93bbe5e7eb7ee"
+PKG_GIT_CLONE_BRANCH="rtl8189fs"
+
+PKG_NAME="RTL8189FS-allw"
+PKG_ARCH="arm"
+PKG_LICENSE="GPL"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_LONGDESC="Realtek RTL8189FS Linux driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make  \
+    M=$PKG_BUILD \
+    ARCH=$TARGET_KERNEL_ARCH \
+    KSRC=$(kernel_path) \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+	all
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    find $PKG_BUILD/ -name \*.ko -not -path '*/\.*' -exec cp {} $INSTALL/$(get_full_module_dir)/RTL8189FS \;
+}

--- a/packages/linux-drivers/allwinner/RTL8189FS-allw/patches/rtw_android_removeaccess_ok_parameter.patch
+++ b/packages/linux-drivers/allwinner/RTL8189FS-allw/patches/rtw_android_removeaccess_ok_parameter.patch
@@ -1,0 +1,19 @@
+commit a1080474b0d763770baaf18db8a192c51c501985
+Author: PeterSz <petersz@vp.pl>
+Date:   Fri Mar 15 10:29:22 2019 +0100
+
+    access_ok takes now 2 parameters
+
+diff --git a/os_dep/linux/rtw_android.c b/os_dep/linux/rtw_android.c
+index 9f18d7a..183a861 100644
+--- a/os_dep/linux/rtw_android.c
++++ b/os_dep/linux/rtw_android.c
+@@ -626,7 +626,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
+ 		goto exit;
+ 	}
+ 
+-	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)){
++	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)){
+ 	 	DBG_871X("%s: failed to access memory\n", __FUNCTION__);
+ 		ret = -EFAULT;
+ 		goto exit;

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -34,6 +34,12 @@
         ;;
     esac
 
+  # additional drivers to install:
+  # for a list of additinoal drivers see packages/linux-drivers
+  # Space separated list is supported,
+  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS RTL8189FS-allw"
+
   # Kernel target
     KERNEL_TARGET="zImage"
 


### PR DESCRIPTION
I've added new module for RTL8189FLV driver from https://github.com/jwrdegoede/rtl8189ES_linux with patch for 5.0 kernel for my Ornage Pi Plus 2e board and it seems to work. It need more testing but it's good beginning.